### PR TITLE
Fixing "top-bar" height

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -145,7 +145,7 @@ body {
 
 .top-bar {
   color: #FFFFFF;
-  height: 100px;
+  height: auto;
 }
 
 .top-bar h1 {


### PR DESCRIPTION
Noticed when viewing your website, it was cutting off the <h1> and other info. Simply changing CSS property values from height: 100px; to auto (alternatively, you could take this height declaration out, completely).